### PR TITLE
Avoid large 150B allocation for every pixel

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -61,17 +61,20 @@ fn render_line(line_number: u32, px: f64, py: f64) -> (Vec<u8>, u32) {
     let mut line: Vec<u8> = vec![0; line_size as usize];
 
     for x in 0..WIDTH {
-        let sampled_colours = (0..NB_SAMPLES).map(|_| {
-            let nx = SIZE * (((x as f64) + rng.gen_range(0., 1.0)) / (WIDTH as f64)) + px;
-            let ny =
-                SIZE * (((line_number as f64) + rng.gen_range(0., 1.0)) / (HEIGHT as f64)) + py;
-            let (m_res, m_iter) = mandelbrot_iter(nx, ny);
-            paint(m_res, m_iter)
-        }).map(|(r, g, b)| (r as i32, g as i32, b as i32));
+        let sampled_colours = (0..NB_SAMPLES)
+            .map(|_| {
+                let nx = SIZE * (((x as f64) + rng.gen_range(0., 1.0)) / (WIDTH as f64)) + px;
+                let ny =
+                    SIZE * (((line_number as f64) + rng.gen_range(0., 1.0)) / (HEIGHT as f64)) + py;
+                let (m_res, m_iter) = mandelbrot_iter(nx, ny);
+                paint(m_res, m_iter)
+            })
+            .map(|(r, g, b)| (r as i32, g as i32, b as i32));
 
-
-        let (r, g, b): (i32, i32, i32) = sampled_colours.fold((0, 0, 0), | (cr, cg, cb), (r, g, b)| (cr + r, cg + g, cb + b));
-
+        let (r, g, b): (i32, i32, i32) = sampled_colours
+            .fold((0, 0, 0), |(cr, cg, cb), (r, g, b)| {
+                (cr + r, cg + g, cb + b)
+            });
 
         line[(x * 3) as usize] = ((r as f64) / (NB_SAMPLES as f64)) as u8;
         line[((x * 3) + 1) as usize] = ((g as f64) / (NB_SAMPLES as f64)) as u8;

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,33 +58,20 @@ fn render_line(line_number: u32, px: f64, py: f64) -> (Vec<u8>, u32) {
     let mut rng = thread_rng();
 
     let line_size = WIDTH * 3;
-    let mut line: Vec<u8> = Vec::with_capacity(line_size as usize);
-    line.resize(line_size as usize, 0);
+    let mut line: Vec<u8> = vec![0; line_size as usize];
 
     for x in 0..WIDTH {
-        let sampled_size = NB_SAMPLES * 3;
-        let mut sampled_colours: Vec<u8> = Vec::with_capacity(sampled_size as usize);
-        sampled_colours.resize(sampled_size as usize, 0);
-
-        for i in 0..NB_SAMPLES {
+        let sampled_colours = (0..NB_SAMPLES).map(|_| {
             let nx = SIZE * (((x as f64) + rng.gen_range(0., 1.0)) / (WIDTH as f64)) + px;
             let ny =
                 SIZE * (((line_number as f64) + rng.gen_range(0., 1.0)) / (HEIGHT as f64)) + py;
             let (m_res, m_iter) = mandelbrot_iter(nx, ny);
-            let (paint_r, paint_g, paint_b) = paint(m_res, m_iter);
+            paint(m_res, m_iter)
+        });
 
-            sampled_colours[(i * 3) as usize] = paint_r;
-            sampled_colours[((i * 3) + 1) as usize] = paint_g;
-            sampled_colours[((i * 3) + 2) as usize] = paint_b;
-        }
-        let mut r: i32 = 0;
-        let mut g: i32 = 0;
-        let mut b: i32 = 0;
-        for i in 0..NB_SAMPLES {
-            r += (sampled_colours[(i * 3) as usize]) as i32;
-            g += (sampled_colours[((i * 3) + 1) as usize]) as i32;
-            b += (sampled_colours[((i * 3) + 2) as usize]) as i32;
-        }
+
+        let (r, g, b) = sampled_colours.fold((0, 0, 0), | (cr, cg, cb), (r, g, b)| (cr + r, cg + g, cb + b));
+
 
         line[(x * 3) as usize] = ((r as f64) / (NB_SAMPLES as f64)) as u8;
         line[((x * 3) + 1) as usize] = ((g as f64) / (NB_SAMPLES as f64)) as u8;

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,10 +67,10 @@ fn render_line(line_number: u32, px: f64, py: f64) -> (Vec<u8>, u32) {
                 SIZE * (((line_number as f64) + rng.gen_range(0., 1.0)) / (HEIGHT as f64)) + py;
             let (m_res, m_iter) = mandelbrot_iter(nx, ny);
             paint(m_res, m_iter)
-        });
+        }).map(|(r, g, b)| (r as i32, g as i32, b as i32));
 
 
-        let (r, g, b) = sampled_colours.fold((0, 0, 0), | (cr, cg, cb), (r, g, b)| (cr + r, cg + g, cb + b));
+        let (r, g, b): (i32, i32, i32) = sampled_colours.fold((0, 0, 0), | (cr, cg, cb), (r, g, b)| (cr + r, cg + g, cb + b));
 
 
         line[(x * 3) as usize] = ((r as f64) / (NB_SAMPLES as f64)) as u8;


### PR DESCRIPTION
Since NB samples allocates 3 bytes (for each color channel) times 50 (`NB_SAMPLES`), but only uses the storage to store intermediate results for a computation, it is possible to entirely eliminate the allocation by using Rust iterators.

The resulting image is visually identical to the previous commit.
I was going to submit hashes to prove this statement, but this is not possible since the result is not deterministic.
Hopefully this picture, generated by commit c2665bf is convincing enough :).

![fractal](https://user-images.githubusercontent.com/33424649/99921859-dad48280-2cf2-11eb-9103-dee655cb8c1c.png)
