### PR TITLE
Remove tokio dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "0.3", features = ["full"] }
 image = "0.23.12"
 rand = "0.7.3"
+num_cpus = "1.13.0"


### PR DESCRIPTION
Substituted with a manually chunked std::thread approach.
While this does use a different dependency, it's significantly less dependencies overall.

Currently, this decreases performance by a couple milliseconds on my machine, but hopefully I will fix this in the next few commits.
I'm going to create some benchmarks to calculate the best buffer size for the channel as well.